### PR TITLE
Fix compile error on visionOS Beta 4 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Take stereoscopic (3D) screenshots in the visionOS simulator.
 
 An example screenshot from the visionOS simulator in side-by-side stereo.
 
-Tested on macOS 14 beta 2 / Xcode 15 beta 2.
+Tested on macOS 14 / Xcode 15.1 beta 2 (visionOS Beta 4 SDK).
 
 ## Setup
 

--- a/visionos_stereo_screenshots.m
+++ b/visionos_stereo_screenshots.m
@@ -129,24 +129,24 @@ static id<MTLTexture> hook_cp_drawable_get_depth_texture(cp_drawable_t drawable,
 
 DYLD_INTERPOSE(hook_cp_drawable_get_depth_texture, cp_drawable_get_depth_texture);
 
-size_t cp_layer_properties_get_view_count(cp_layer_renderer_properties_t properties);
+size_t cp_layer_renderer_properties_get_view_count(cp_layer_renderer_properties_t properties);
 
-static size_t hook_cp_layer_properties_get_view_count(cp_layer_renderer_properties_t properties) {
+static size_t hook_cp_layer_renderer_properties_get_view_count(cp_layer_renderer_properties_t properties) {
   return 2;
 }
 
-DYLD_INTERPOSE(hook_cp_layer_properties_get_view_count, cp_layer_properties_get_view_count);
+DYLD_INTERPOSE(hook_cp_layer_renderer_properties_get_view_count, cp_layer_renderer_properties_get_view_count);
 
-cp_layer_renderer_layout cp_layer_configuration_get_layout_private(
+cp_layer_renderer_layout cp_layer_renderer_configuration_get_layout(
     cp_layer_renderer_configuration_t configuration);
 
-static cp_layer_renderer_layout hook_cp_layer_configuration_get_layout_private(
+static cp_layer_renderer_layout hook_cp_layer_renderer_configuration_get_layout(
     cp_layer_renderer_configuration_t configuration) {
   return cp_layer_renderer_layout_dedicated;
 }
 
-DYLD_INTERPOSE(hook_cp_layer_configuration_get_layout_private,
-               cp_layer_configuration_get_layout_private);
+DYLD_INTERPOSE(hook_cp_layer_renderer_configuration_get_layout,
+               cp_layer_renderer_configuration_get_layout);
 
 static void DumpScreenshot() {
   NSLog(@"visionos_stereo_screenshot: DumpScreenshot");


### PR DESCRIPTION
The latest visionOS Beta have some API change, cause this project to build (link) fail with errors:

```
ld: Undefined symbols:
  _cp_layer_configuration_get_layout_private, referenced from:
      __interpose_cp_layer_configuration_get_layout_private in visionos_stereo_screenshots-60b7c2.o
  _cp_layer_properties_get_view_count, referenced from:
      __interpose_cp_layer_properties_get_view_count in visionos_stereo_screenshots-60b7c2.o
```

This commit modified the source to use new apis